### PR TITLE
EVA Construction compability

### DIFF
--- a/GameData/EVATransfer/EVAFuelLine/EVAFuelLine.cfg
+++ b/GameData/EVATransfer/EVAFuelLine/EVAFuelLine.cfg
@@ -71,6 +71,13 @@ PART
 		transferOre = True
 		transferAll = True				//Specify all other resources that have a valid transfer mode (ie no solid fuel)
 	}
+	
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 10
+	}
+	
 	DRAG_CUBE
 	{
 		none = True


### PR DESCRIPTION
I've added the ModuleCargoPart module to the eva fuel line config. Now the part can be added to the stock inventory slots, and can be bolted on a craft by an engineer.
The volume is the same as the stock fuel transfer tube.
I didn't carry over the stacking option, because the use case doesn't require more than one imo.

Also, it works kinda fine in KSP 1.12.2, but I didn't want to touch the version file. I can create issues for the kinks I've found if you're still managing this mod.